### PR TITLE
feat[--exclude-folder]: An option to exclude folder

### DIFF
--- a/bin/newman.js
+++ b/bin/newman.js
@@ -28,6 +28,9 @@ program
     .option('--folder <path>',
         'Specify the folder to run from a collection. Can be specified multiple times to run multiple folders',
         util.cast.memoize, [])
+    .option('--exclude-folder <path>',
+        'Specify the folder to exclude from a collection. Can be specified multiple times to exclude multiple folders',
+        util.cast.memoize, [])
     .option('--global-var <value>',
         'Allows the specification of global variables via the command line, in a key=value format',
         util.cast.memoizeKeyVal, [])
@@ -102,7 +105,7 @@ program.on('command:*', (command) => {
  * @param {String[]} argv - Argument vector.
  * @param {?Function} callback - The callback function invoked on the completion of execution.
  */
-function run (argv, callback) {
+function run(argv, callback) {
     waterfall([
         (next) => {
             // cache original argv, required to parse nested options later.

--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -65,6 +65,14 @@ var _ = require('lodash'),
      */
     MULTIENTRY_LOOKUP_STRATEGY = 'multipleIdOrName';
 
+    /**
+     * Multiple items ignore strategy.
+     *
+     * @private
+     * @type {String}
+     */
+    MULTIPLE_IGNORE_STRATEGY = 'itemsOrGroups';
+
 /**
  * Runs the collection, with all the provided options, returning an EventEmitter.
  *
@@ -95,7 +103,8 @@ module.exports = function (options, callback) {
     var emitter = new EventEmitter(), // @todo: create a new inherited constructor
         runner = new runtime.Runner(),
         stopOnFailure,
-        entrypoint;
+        entrypoint,
+        exclude;
 
     // get the configuration from various sources
     getOptions(options, function (err, options) {
@@ -142,6 +151,14 @@ module.exports = function (options, callback) {
             _.isArray(entrypoint.execute) && (entrypoint.lookupStrategy = MULTIENTRY_LOOKUP_STRATEGY);
         }
 
+        // sets exclude to ignore if options.excludeFolder is specified.
+        if (options.excludeFolder) {
+            exclude = { ignore: options.excludeFolder };
+
+            // uses `findItemsOrGroups` ignoreStrategy in case of multiple folders.
+            _.isArray(exclude.ignore) && (exclude.ignoreStrategy = MULTIPLE_IGNORE_STRATEGY);
+        }
+        
         // sets stopOnFailure to true in case bail is used without any modifiers or with failure
         // --bail => stopOnFailure = true
         // --bail failure => stopOnFailure = true
@@ -167,6 +184,7 @@ module.exports = function (options, callback) {
             environment: options.environment,
             globals: options.globals,
             entrypoint: entrypoint,
+            exclude: exclude,
             data: options.iterationData,
             delay: {
                 item: options.delayRequest
@@ -225,7 +243,7 @@ module.exports = function (options, callback) {
                  * @param {Object} cursor - The run cursor instance.
                  * @returns {*}
                  */
-                start (err, cursor) {
+                start(err, cursor) {
                     emitter.emit('start', err, {
                         cursor,
                         run
@@ -239,7 +257,7 @@ module.exports = function (options, callback) {
                  * @param {String} level - The level of console logging [error, silent, etc].
                  * @returns {*}
                  */
-                console (cursor, level) {
+                console(cursor, level) {
                     emitter.emit('console', null, {
                         cursor: cursor,
                         level: level,
@@ -255,14 +273,14 @@ module.exports = function (options, callback) {
                  * @param {?Error} err - An Error instance / null object.
                  * @returns {*}
                  */
-                exception (cursor, err) {
+                exception(cursor, err) {
                     emitter.emit('exception', null, {
                         cursor: cursor,
                         error: err
                     });
                 },
 
-                assertion (cursor, assertions) {
+                assertion(cursor, assertions) {
                     _.forEach(assertions, function (assertion) {
                         var errorName = _.get(assertion, 'error.name', 'AssertionError');
 
@@ -298,7 +316,7 @@ module.exports = function (options, callback) {
                  * @param {Object} cursor - The run instance cursor.
                  * @returns {*}
                  */
-                done (err, cursor) {
+                done(err, cursor) {
                     // in case runtime faced an error during run, we do not process any other event and emit `done`.
                     // we do it this way since, an error in `done` callback would have anyway skipped any intermediate
                     // events or callbacks

--- a/lib/run/options.js
+++ b/lib/run/options.js
@@ -256,6 +256,26 @@ var _ = require('lodash'),
         },
 
         /**
+         * Helper function to sanitize exclude-folder option.
+         *
+         * @param {String[]|String} value - The list of folders to exclude from execution
+         * @param {Object} options - The set of wrapped options.
+         * @param {Function} callback - The callback function invoked to mark the end of the folder load routine.
+         * @returns {*}
+         */
+        excludeFolder: function (value, options, callback) {
+            if (!value.length) {
+                return callback(); // avoids empty string or array
+            }
+
+            if (Array.isArray(value) && value.length === 1) {
+                return callback(null, value[0]); // avoids using multipleIdOrName strategy for a single item array
+            }
+
+            callback(null, value);
+        },
+
+        /**
          * The iterationData loader module, with support for JSON or CSV data files.
          *
          * @param {String|Object[]} location - The path to the iteration data file for the current collection run, or
@@ -373,6 +393,9 @@ var _ = require('lodash'),
 module.exports = function (options, callback) {
     // set newman version used for collection run
     options.newmanVersion = util.version;
+
+    // sets excludeFolder to undefined if not provided
+    if (!options.excludeFolder) { options.excludeFolder = undefined; }
 
     // set working directory if not provided
     options.workingDir = options.workingDir || process.cwd();


### PR DESCRIPTION
Taken from https://github.com/postmanlabs/newman/pull/2709

Untested.  

Also, I wanted to know is it possible to make the existing `newman-dir` to support live export. By this, I mean, what ever the changes made in postman to the collection, has to reflect in the json file without the user explicitly exporting and importing the collections?