### PR TITLE
Add flake.nix, -q, -o flags, CSV formatting, and pretty-print fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 # - Prevent unit test coverage reports from being committed to the repository
 .coverage
 .nyc_output
+
+# - Prevent Nix build output symlink from being committed
+result

--- a/.npmignore
+++ b/.npmignore
@@ -42,8 +42,10 @@ Thumbs.db
 .coverage
 .nyc_output
 
-# - Prevent Nix build output symlink from being committed
+# - Prevent Nix files from being published
 result
+flake.nix
+flake.lock
 
 # - Prevent config and test files from being added
 .git*

--- a/.npmignore
+++ b/.npmignore
@@ -42,6 +42,9 @@ Thumbs.db
 .coverage
 .nyc_output
 
+# - Prevent Nix build output symlink from being committed
+result
+
 # - Prevent config and test files from being added
 .git*
 npm/

--- a/examples/Sample Postman Collection/.meta.json
+++ b/examples/Sample Postman Collection/.meta.json
@@ -2,6 +2,8 @@
   "childrenOrder": [
     "A simple GET request",
     "A simple POST request",
-    "A simple POST request with JSON body"
+    "A simple POST request with JSON body",
+    "A simple POST request with CSV body",
+    "A simple POST request with unquoted variables"
   ]
 }

--- a/examples/Sample Postman Collection/A simple POST request with CSV body/request.json
+++ b/examples/Sample Postman Collection/A simple POST request with CSV body/request.json
@@ -1,0 +1,18 @@
+{
+  "url": "https://postman-echo.com/post",
+  "method": "POST",
+  "header": [
+    {
+      "key": "Content-Type",
+      "value": "text/csv"
+    }
+  ],
+  "body": {
+    "mode": "raw",
+    "raw_csv_formatted": [
+      "name,age,city",
+      "Alice,30,Mumbai",
+      "Bob,25,Delhi"
+    ]
+  }
+}

--- a/examples/Sample Postman Collection/A simple POST request with unquoted variables/request.json
+++ b/examples/Sample Postman Collection/A simple POST request with unquoted variables/request.json
@@ -1,0 +1,17 @@
+{
+  "url": "https://postman-echo.com/post",
+  "method": "POST",
+  "header": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "body": {
+    "mode": "raw",
+    "raw_json_formatted": {
+      "amount": "__UQ__{{amount}}",
+      "currency": "INR"
+    }
+  }
+}

--- a/examples/sample-collection.json
+++ b/examples/sample-collection.json
@@ -54,5 +54,33 @@
         "raw": "{\"text\":\"Duis posuere augue vel cursus pharetra. In luctus a ex nec pretium...\"}"
       }
     }
+  }, {
+    "name": "A simple POST request with CSV body",
+    "request": {
+      "url": "https://postman-echo.com/post",
+      "method": "POST",
+      "header": [{
+        "key": "Content-Type",
+        "value": "text/csv"
+      }],
+      "body": {
+        "mode": "raw",
+        "raw": "name,age,city\nAlice,30,Mumbai\nBob,25,Delhi"
+      }
+    }
+  }, {
+    "name": "A simple POST request with unquoted variables",
+    "request": {
+      "url": "https://postman-echo.com/post",
+      "method": "POST",
+      "header": [{
+        "key": "Content-Type",
+        "value": "application/json"
+      }],
+      "body": {
+        "mode": "raw",
+        "raw": "{\"amount\":{{amount}},\"currency\":\"INR\"}"
+      }
+    }
   }]
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Newman with directory-based collection support";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        packages.default = pkgs.buildNpmPackage {
+          pname = "newman-dir";
+          version = "6.0.0-dir";
+          src = self;
+          npmDepsHash = "sha256-Aeeqfohxl0P+MnVPxzYHQZzetYiAohxaoui45+HxYwY=";
+          dontNpmBuild = true;
+          meta = {
+            description = "Newman with directory-based collection support";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "newman";
+          };
+        };
+      }
+    );
+}

--- a/lib/commands/dir-export/index.js
+++ b/lib/commands/dir-export/index.js
@@ -13,7 +13,8 @@ function cliSetup (program) {
         .usage('<postman-collection-file> [options]')
         .option('-s, --substitute-slashes', 'if slashes are found in name field - substitute them')
         .option('-f, --force-overwrite', 'overwrite if directory already exists')
-        .option('-q, --quote-unquoted-vars', 'quote unquoted {{variables}} in request body with __UQ__ marker so that raw json can be formatted');
+        .option('-q, --quote-unquoted-vars', 'quote unquoted {{variables}} in request body with __UQ__ marker so that raw json can be formatted')
+        .option('-o, --output-dir <directory>', 'output directory for the exported collection');
 }
 
 function action (collectionFile, command) {
@@ -30,12 +31,14 @@ function action (collectionFile, command) {
         collection = collection.collection;
     }
 
+    let outputBase = options.outputDir || '.';
+
     if (options.forceOverwrite) {
-        fs.rmSync(`./${collection.info.name}`, { recursive: true, force: true });
+        fs.rmSync(`${outputBase}/${collection.info.name}`, { recursive: true, force: true });
     }
 
     try {
-        dirUtils.traverse(collection, [], options);
+        dirUtils.traverse(collection, [], options, outputBase);
     }
     catch (e) {
         console.error(e);

--- a/lib/commands/dir-export/index.js
+++ b/lib/commands/dir-export/index.js
@@ -13,7 +13,8 @@ function cliSetup (program) {
         .usage('<postman-collection-file> [options]')
         .option('-s, --substitute-slashes', 'if slashes are found in name field - substitute them')
         .option('-f, --force-overwrite', 'overwrite if directory already exists')
-        .option('-q, --quote-unquoted-vars', 'quote unquoted {{variables}} in request body with __UQ__ marker so that raw json can be formatted')
+        .option('-q, --quote-unquoted-vars',
+            'quote unquoted {{variables}} with __UQ__ marker')
         .option('-o, --output-dir <directory>', 'output directory for the exported collection');
 }
 
@@ -24,14 +25,13 @@ function action (collectionFile, command) {
 
     dirUtils.assertFileExistence(collectionFilePath);
 
-    let collection = require(collectionFilePath);
+    let collection = require(collectionFilePath),
+        outputBase = options.outputDir || '.';
 
     // handle different format postman collection file
     if (collection.collection) {
         collection = collection.collection;
     }
-
-    let outputBase = options.outputDir || '.';
 
     if (options.forceOverwrite) {
         fs.rmSync(`${outputBase}/${collection.info.name}`, { recursive: true, force: true });

--- a/lib/commands/dir-export/index.js
+++ b/lib/commands/dir-export/index.js
@@ -12,7 +12,8 @@ function cliSetup (program) {
         .description('Convert a Postman collection file into its directory representation')
         .usage('<postman-collection-file> [options]')
         .option('-s, --substitute-slashes', 'if slashes are found in name field - substitute them')
-        .option('-f, --force-overwrite', 'overwrite if directory already exists');
+        .option('-f, --force-overwrite', 'overwrite if directory already exists')
+        .option('-q, --quote-unquoted-vars', 'quote unquoted {{variables}} in request body with __UQ__ marker so that raw json can be formatted');
 }
 
 function action (collectionFile, command) {

--- a/lib/commands/dir-import/index.js
+++ b/lib/commands/dir-import/index.js
@@ -9,7 +9,8 @@ function cliSetup (program) {
         .command('dir-import <collection-dir>')
         .description('Convert a Postman directory representation into a postman collection')
         .usage('<collection-dir> [options]')
-        .option('-o, --output-file <file>', 'output collection file, default is collection.json');
+        .option('-o, --output-file <file>', 'output collection file, default is collection.json')
+        .option('-p, --pretty-print-body', 'pretty-print JSON request body with 4-space indent');
 }
 
 function action (collectionDir, command) {
@@ -23,7 +24,7 @@ function action (collectionDir, command) {
     if (typeof (options.outputFile) === 'string') {
         outputFile = options.outputFile;
     }
-    collectionJson = dirUtils.dirTreeToCollectionJson(collectionDir);
+    collectionJson = dirUtils.dirTreeToCollectionJson(collectionDir, options);
 
     content = JSON.stringify(collectionJson, null, 2);
 

--- a/lib/commands/dir-utils.js
+++ b/lib/commands/dir-utils.js
@@ -210,6 +210,16 @@ const os = require('os'),
                 isBodyLangJson = (thing.request.body && thing.request.body.options &&
                     thing.request.body.options.raw && thing.request.body.options.raw.language === 'json');
 
+            let contentTypeCsvHeaderIndex = thing.request.header ? thing.request.header.findIndex((element) => {
+                    return (element.key === 'Content-Type' && element.value === 'text/csv');
+                }) : -1;
+
+            // format CSV body as array of lines
+            if (contentTypeCsvHeaderIndex > -1 && (thing.request.body && thing.request.body.raw)) {
+                thing.request.body.raw_csv_formatted = thing.request.body.raw.split('\n');
+                delete thing.request.body.raw;
+            }
+
             // we have a body in the request
             if ((contentTypeJsonHeaderIndex > -1 || isBodyLangJson) && (thing.request.body && thing.request.body.raw)) {
                 // add raw post body as formatted JSON, will be removed in the import
@@ -296,6 +306,10 @@ const os = require('os'),
                                 '$1'
                             );
                             delete result.request.body.raw_json_formatted;
+                        }
+                        if (result.request.body && result.request.body.raw_csv_formatted) {
+                            result.request.body.raw = result.request.body.raw_csv_formatted.join('\n');
+                            delete result.request.body.raw_csv_formatted;
                         }
                         break;
                     case 'response.json':

--- a/lib/commands/dir-utils.js
+++ b/lib/commands/dir-utils.js
@@ -262,7 +262,7 @@ const os = require('os'),
         }
     },
 
-    walkDirTree = (dirTreeJson, level) => {
+    walkDirTree = (dirTreeJson, level, options) => {
     // console.log(JSON.stringify(dirTreeJson, null, 2));
         const { path, name, children, type } = dirTreeJson;
         let items,
@@ -300,7 +300,9 @@ const os = require('os'),
                             request: JSON.parse(fs.readFileSync(path))
                         };
                         if (result.request.body && result.request.body.raw_json_formatted) {
-                            result.request.body.raw = JSON.stringify(result.request.body.raw_json_formatted);
+                            result.request.body.raw = options.prettyPrintBody ?
+                                JSON.stringify(result.request.body.raw_json_formatted, null, 4) :
+                                JSON.stringify(result.request.body.raw_json_formatted);
                             result.request.body.raw = result.request.body.raw.replace(
                                 /"__UQ__(\{\{[^}]+\}\})"/g,
                                 '$1'
@@ -359,7 +361,7 @@ const os = require('os'),
                     // ignore if .meta.json does not exist
                     }
                     children.forEach((child) => {
-                        let output = walkDirTree(child, level + 1);
+                        let output = walkDirTree(child, level + 1, options);
 
                         if (child.type === 'file') {
                             if (child.name.match(/event/)) {
@@ -409,10 +411,10 @@ const os = require('os'),
         return result;
     },
 
-    dirTreeToCollectionJson = function (collectionDir) {
+    dirTreeToCollectionJson = function (collectionDir, options) {
         const tree = dirTree(collectionDir,
                 { attributes: ['type'], exclude: /\.meta\.json/ }),
-            collectionJson = walkDirTree(tree, 0);
+            collectionJson = walkDirTree(tree, 0, options || {});
 
         return collectionJson;
     },

--- a/lib/commands/dir-utils.js
+++ b/lib/commands/dir-utils.js
@@ -218,7 +218,23 @@ const os = require('os'),
                     delete thing.request.body.raw;
                 }
                 catch (e) {
-                    console.warn(`Unable to parse raw body for ${name}`);
+                    if (options.quoteUnquotedVars) {
+                        try {
+                            let sanitized = thing.request.body.raw.replace(
+                                /:\s*(\{\{[^}]+\}\})\s*([,\n\r}\]])/g,
+                                ': "__UQ__$1"$2'
+                            );
+
+                            thing.request.body.raw_json_formatted = JSON.parse(sanitized);
+                            delete thing.request.body.raw;
+                        }
+                        catch (e2) {
+                            console.warn(`Unable to parse raw body for ${name}`);
+                        }
+                    }
+                    else {
+                        console.warn(`Unable to parse raw body for ${name}`);
+                    }
                 }
             }
 
@@ -275,6 +291,10 @@ const os = require('os'),
                         };
                         if (result.request.body && result.request.body.raw_json_formatted) {
                             result.request.body.raw = JSON.stringify(result.request.body.raw_json_formatted);
+                            result.request.body.raw = result.request.body.raw.replace(
+                                /"__UQ__(\{\{[^}]+\}\})"/g,
+                                '$1'
+                            );
                             delete result.request.body.raw_json_formatted;
                         }
                         break;

--- a/lib/commands/dir-utils.js
+++ b/lib/commands/dir-utils.js
@@ -119,8 +119,8 @@ const os = require('os'),
         auth: 1
     },
 
-    traverse = (thing, ancestors, options) => {
-        let parent = './' + ancestors.join('/'),
+    traverse = (thing, ancestors, options, outputBase) => {
+        let parent = (outputBase || '.') + '/' + ancestors.join('/'),
             elementOrder = [],
             elementMap = {},
             itemDir,
@@ -182,7 +182,7 @@ const os = require('os'),
                 elementMap[element.name] = true;
 
                 elementOrder.push(sanitizePathName(element.name));
-                traverse(element, newParent, options);
+                traverse(element, newParent, options, outputBase);
             });
 
             meta = {

--- a/lib/commands/dir-utils.js
+++ b/lib/commands/dir-utils.js
@@ -119,6 +119,20 @@ const os = require('os'),
         auth: 1
     },
 
+    quoteAndParseBody = (thing) => {
+        try {
+            let sanitized = thing.request.body.raw.replace(/:\s*(\{\{[^}]+\}\})\s*([,\n\r}\]])/g, ': "__UQ__$1"$2');
+
+            thing.request.body.raw_json_formatted = JSON.parse(sanitized);
+            delete thing.request.body.raw;
+
+            return true;
+        }
+        catch (e) {
+            return false;
+        }
+    },
+
     traverse = (thing, ancestors, options, outputBase) => {
         let parent = (outputBase || '.') + '/' + ancestors.join('/'),
             elementOrder = [],
@@ -208,9 +222,8 @@ const os = require('os'),
                     return (element.key === 'Content-Type' && element.value === 'application/json');
                 }) : -1,
                 isBodyLangJson = (thing.request.body && thing.request.body.options &&
-                    thing.request.body.options.raw && thing.request.body.options.raw.language === 'json');
-
-            let contentTypeCsvHeaderIndex = thing.request.header ? thing.request.header.findIndex((element) => {
+                    thing.request.body.options.raw && thing.request.body.options.raw.language === 'json'),
+                contentTypeCsvHeaderIndex = thing.request.header ? thing.request.header.findIndex((element) => {
                     return (element.key === 'Content-Type' && element.value === 'text/csv');
                 }) : -1;
 
@@ -228,21 +241,10 @@ const os = require('os'),
                     delete thing.request.body.raw;
                 }
                 catch (e) {
-                    if (options.quoteUnquotedVars) {
-                        try {
-                            let sanitized = thing.request.body.raw.replace(
-                                /:\s*(\{\{[^}]+\}\})\s*([,\n\r}\]])/g,
-                                ': "__UQ__$1"$2'
-                            );
-
-                            thing.request.body.raw_json_formatted = JSON.parse(sanitized);
-                            delete thing.request.body.raw;
-                        }
-                        catch (e2) {
-                            console.warn(`Unable to parse raw body for ${name}`);
-                        }
+                    if (!options.quoteUnquotedVars) {
+                        console.warn(`Unable to parse raw body for ${name}`);
                     }
-                    else {
+                    else if (!quoteAndParseBody(thing, name)) {
                         console.warn(`Unable to parse raw body for ${name}`);
                     }
                 }
@@ -303,10 +305,7 @@ const os = require('os'),
                             result.request.body.raw = options.prettyPrintBody ?
                                 JSON.stringify(result.request.body.raw_json_formatted, null, 4) :
                                 JSON.stringify(result.request.body.raw_json_formatted);
-                            result.request.body.raw = result.request.body.raw.replace(
-                                /"__UQ__(\{\{[^}]+\}\})"/g,
-                                '$1'
-                            );
+                            result.request.body.raw = result.request.body.raw.replace(/"__UQ__(\{\{[^}]+\}\})"/g, '$1');
                             delete result.request.body.raw_json_formatted;
                         }
                         if (result.request.body && result.request.body.raw_csv_formatted) {

--- a/test/unit/dir-utils.test.js
+++ b/test/unit/dir-utils.test.js
@@ -89,6 +89,33 @@ describe('dir-utils tests', function () {
         done();
     });
 
+    it('should convert collection with -q flag to directory tree and back', function (done) {
+        const dir = dirUtils.createTempDir(),
+            collectionJSON = JSON.parse(fs.readFileSync('examples/sample-collection.json')),
+            currentDir = process.cwd();
+
+        process.chdir(dir);
+        dirUtils.traverse(collectionJSON, [], { quoteUnquotedVars: true });
+        process.chdir(currentDir);
+
+        let recreatedCollectionJSON = dirUtils.dirTreeToCollectionJson(path.join(dir, 'Sample Postman Collection'));
+
+        expect(recreatedCollectionJSON).to.deep.equal(JSON.parse(fs.readFileSync('examples/sample-collection.json')));
+
+        fs.rmSync(dir, { recursive: true, force: true });
+        done();
+    });
+
+    it('should pretty-print JSON body with -p flag on import', function (done) {
+        const collectionDir = 'examples/Sample Postman Collection',
+            result = dirUtils.dirTreeToCollectionJson(collectionDir, { prettyPrintBody: true }),
+            jsonBodyItem = result.item.find((item) => { return item.name === 'A simple POST request with JSON body'; });
+
+        expect(jsonBodyItem.request.body.raw).to.contain('\n');
+        expect(jsonBodyItem.request.body.raw).to.equal(JSON.stringify(JSON.parse(jsonBodyItem.request.body.raw), null, 4));
+        done();
+    });
+
     it('should create and remove postman folders under an collection', function (done) {
         dirUtils.createPostmanFolder('examples/Sample Postman Collection/foo');
         dirUtils.removePostmanFolder('examples/Sample Postman Collection/foo');

--- a/test/unit/dir-utils.test.js
+++ b/test/unit/dir-utils.test.js
@@ -111,8 +111,10 @@ describe('dir-utils tests', function () {
             result = dirUtils.dirTreeToCollectionJson(collectionDir, { prettyPrintBody: true }),
             jsonBodyItem = result.item.find((item) => { return item.name === 'A simple POST request with JSON body'; });
 
-        expect(jsonBodyItem.request.body.raw).to.contain('\n');
-        expect(jsonBodyItem.request.body.raw).to.equal(JSON.stringify(JSON.parse(jsonBodyItem.request.body.raw), null, 4));
+        let rawBody = jsonBodyItem.request.body.raw;
+
+        expect(rawBody).to.contain('\n');
+        expect(rawBody).to.equal(JSON.stringify(JSON.parse(rawBody), null, 4));
         done();
     });
 


### PR DESCRIPTION
## Summary

- Add `flake.nix` for Nix-based installation
- Add `-q` (`--quote-unquoted-vars`) flag to `dir-export` — quotes unquoted `{{variables}}` in request body with `__UQ__` marker so raw JSON can be formatted as `raw_json_formatted`
- Add `-o` (`--output-dir`) flag to `dir-export` — specify output directory instead of always using current working directory
- Add CSV body formatting — detects `text/csv` Content-Type and splits raw body into `raw_csv_formatted` array of lines for readability
- Add `-p` (`--pretty-print-body`) flag to `dir-import` — opt-in 4-space indent for JSON request body, matching Postman's formatting. Without `-p`, body stays minified as before.

## Test plan

- [x] `-q` flag: tested with collections containing unquoted `{{variables}}` — body gets `__UQ__` markers, round-trip restores unquoted form
- [x] `-o` flag: tested with `dir-export -o smoketests` — directory created in specified location
- [x] CSV formatting: tested with `text/csv` requests — body split into array of lines, round-trip preserves original
- [x] `-p` flag: tested `dir-import -p` — body formatted with 4-space indent in Postman

🤖 Generated with [Claude Code](https://claude.com/claude-code)